### PR TITLE
Posix path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.12
+  - 10
 
 script:
   - npm run ci

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var request = require('./lib/node/request'),
 	qs = require('qs'),
 	crypto = require('./lib/node/crypto'),
 	printf = require('util').format,
-	join = require('path').join;
+	join = require('path').posix.join;
 
 /**
  * Extend `target` with properties from `source`.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var request = require('./lib/node/request'),
 	qs = require('qs'),
 	crypto = require('./lib/node/crypto'),
 	printf = require('util').format,
-	join = require('path').posix.join;
+	path = require('path'),
+	join = path.posix ? path.posix.join : path.join;
 
 /**
  * Extend `target` with properties from `source`.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jshint": "^2.8.0",
     "karma": "^0.13.14",
     "karma-mocha": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "mocha": "^1.21.4",
     "nock": "^2.16.1",
     "phantomjs": "^1.9.18",


### PR DESCRIPTION
Using `path.join` to build URLs does not work out of the box on Windows, as you end up with Windows-style path separators (\ instead of /).

The path-module has win32 and posix sub-modules to ensure the right paths are built regardless of which platform the module runs on. See https://nodejs.org/api/path.html#path_windows_vs_posix

The client defaults to regular path.join if the posix namespace does not exist (browser builds).

Upgrades to node and karma-phantomjs-launcher were necessary for tests to pass.